### PR TITLE
132 enhancement create a description of the taxa table in the same format as the table legend

### DIFF
--- a/alienSpecies/R/tableIndicators.R
+++ b/alienSpecies/R/tableIndicators.R
@@ -92,30 +92,6 @@ tableIndicatorsServer <- function(id, exotenData, unionlistData, occurrenceData,
       ns <- session$ns
       selectedKey <- reactiveVal()
       
-      ### Legend
-      ### -----------------
-      
-      output$tableLegendLink <- renderUI({
-          
-          actionLink(inputId = ns("tableShowLegend"), 
-            label = translate(uiText(), "tableLegend")$title, 
-            icon = icon("angle-double-down", class = "green-icon"))
-          
-        })
-      
-      output$tableLegendText <- renderUI({
-          
-          tagList(
-            tags$b(translate(uiText(), "icons")$title),
-            p(icon("star"), translate(uiText(), "is_union")$title),
-            p(icon("play"), translate(uiText(), "min_1_obs")$title),
-            tags$b(translate(uiText(), "colors")$title),
-            p(drawBullet(color = "black"), translate(uiText(), "only_obs")$title),
-#            p(drawBullet(color = "orange"), translate(uiText(), "incomplete_out")$title),
-            p(drawBullet(color = "#E4E517"), translate(uiText(), "all_out")$title)
-          )
-          
-        })
       
       
       ### Table overview

--- a/alienSpecies/R/tableIndicators.R
+++ b/alienSpecies/R/tableIndicators.R
@@ -108,15 +108,18 @@ tableIndicatorsServer <- function(id, exotenData, unionlistData, occurrenceData,
       output$tableOverviewText <- renderUI({
         tagList(
           tags$em(HTML(translate(uiText(), "tableIndicators")$description)),
-          p(icon("star"), translate(uiText(), "is_union")$title),
-          p(icon("play"), translate(uiText(), "min_1_obs")$title),
-          tags$em(translate(uiText(), "colors_text")$title),
-          p(drawBullet(color = "black"), translate(uiText(), "only_obs")$title),
-          #            p(drawBullet(color = "orange"), translate(uiText(), "incomplete_out")$title),
-          p(drawBullet(color = "#E4E517"), translate(uiText(), "all_out")$title)
+          div(style = "margin-left: 20px;",
+              p(style = "margin: 2px 0;",icon("star"), tags$em(HTML(translate(uiText(), "is_union")$title))),
+              p(style = "margin: 2px 0;",icon("play"), tags$em(HTML(translate(uiText(), "min_1_obs")$title)))
+              ),
+              tags$em(HTML(translate(uiText(), "colors_text")$title)),
+          div(style = "margin-left: 20px;",
+              p(style = "margin: 2px 0;",drawBullet(color = "black"), tags$em(HTML(translate(uiText(), "only_obs")$title))),
+              #            p(drawBullet(color = "orange"), translate(uiText(), "incomplete_out")$title),
+              p(style = "margin: 2px 0;",drawBullet(color = "#E4E517"), tags$em(HTML(translate(uiText(), "all_out")$title)))
+          )
         )
-          
-        })
+      })
       
       ### Table Output
       ### -----------------

--- a/alienSpecies/R/tableIndicators.R
+++ b/alienSpecies/R/tableIndicators.R
@@ -92,13 +92,6 @@ tableIndicatorsServer <- function(id, exotenData, unionlistData, occurrenceData,
       ns <- session$ns
       selectedKey <- reactiveVal()
       
-      
-      output$disclaimerTableIndicators <- renderUI({
-          
-          tags$em(HTML(translate(uiText(), "tableIndicators")$description))
-          
-        })
-      
       output$table <- renderDT({
           
           validate(need(nrow(exotenData()) > 0, "No data available"))

--- a/alienSpecies/R/tableIndicators.R
+++ b/alienSpecies/R/tableIndicators.R
@@ -106,8 +106,15 @@ tableIndicatorsServer <- function(id, exotenData, unionlistData, occurrenceData,
         })
       
       output$tableOverviewText <- renderUI({
-          
-          tags$em(HTML(translate(uiText(), "tableIndicators")$description))
+        tagList(
+          tags$em(HTML(translate(uiText(), "tableIndicators")$description)),
+          p(icon("star"), translate(uiText(), "is_union")$title),
+          p(icon("play"), translate(uiText(), "min_1_obs")$title),
+          tags$em(translate(uiText(), "colors_text")$title),
+          p(drawBullet(color = "black"), translate(uiText(), "only_obs")$title),
+          #            p(drawBullet(color = "orange"), translate(uiText(), "incomplete_out")$title),
+          p(drawBullet(color = "#E4E517"), translate(uiText(), "all_out")$title)
+        )
           
         })
       

--- a/alienSpecies/inst/app/serverFiles/serverChecklist.R
+++ b/alienSpecies/inst/app/serverFiles/serverChecklist.R
@@ -346,7 +346,10 @@ output$exoten_legendText <- renderUI({
 
 ### Table overview
 ### -----------------
-
+uiText <- reactive({
+  results$translations
+})
+                         
 output$exoten_overviewLink <- renderUI({
   
   actionLink(inputId = "exoten_overview", 
@@ -357,7 +360,7 @@ output$exoten_overviewLink <- renderUI({
 
 output$exoten_overviewText <- renderUI({
     
-   tags$em(HTML(translate(reactive(results$translations), "tableIndicators")$description))
+   tags$em(HTML(translate(uiText(), "tableIndicators")$description))
     
   })
 

--- a/alienSpecies/inst/app/serverFiles/serverChecklist.R
+++ b/alienSpecies/inst/app/serverFiles/serverChecklist.R
@@ -344,6 +344,17 @@ output$exoten_legendText <- renderUI({
   })
 
 
+### Table overview
+### -----------------
+
+output$exoten_overviewLink <- renderUI({
+  
+  actionLink(inputId = "exoten_overview", 
+             label = translate(results$translations, "tableTitle")$title, 
+             icon = icon("angle-double-down", class = "green-icon"))
+  
+})
+
 output$exoten_overviewText <- renderUI({
     
     tags$em(HTML(translate(uiText(), "tableIndicators")$description))

--- a/alienSpecies/inst/app/serverFiles/serverChecklist.R
+++ b/alienSpecies/inst/app/serverFiles/serverChecklist.R
@@ -344,6 +344,12 @@ output$exoten_legendText <- renderUI({
   })
 
 
+output$exoten_overviewText <- renderUI({
+    
+    tags$em(HTML(translate(uiText(), "tableIndicators")$description))
+    
+  })
+
 
 ### Table
 ### -----------------

--- a/alienSpecies/inst/app/serverFiles/serverChecklist.R
+++ b/alienSpecies/inst/app/serverFiles/serverChecklist.R
@@ -357,7 +357,7 @@ output$exoten_overviewLink <- renderUI({
 
 output$exoten_overviewText <- renderUI({
     
-    tags$em(HTML(translate(uiText(), "tableIndicators")$description))
+   tags$em(HTML(translate(reactive(results$translations), "tableIndicators")$description))
     
   })
 

--- a/alienSpecies/inst/app/uiFiles/uiChecklist.R
+++ b/alienSpecies/inst/app/uiFiles/uiChecklist.R
@@ -75,7 +75,7 @@ tagList(
               uiOutput("exoten_legendText")              
             )
           ),
-         uiOutput("exoten_overviewLink"),
+          uiOutput("exoten_overviewLink"),
           conditionalPanel("input.exoten_overview % 2 == 1",
             wellPanel(
               uiOutput("exoten_overviewText")

--- a/alienSpecies/inst/app/uiFiles/uiChecklist.R
+++ b/alienSpecies/inst/app/uiFiles/uiChecklist.R
@@ -74,6 +74,12 @@ tagList(
             wellPanel(
               uiOutput("exoten_legendText")              
             )
+          ),
+         uiOutput("exoten_overviewLink"),
+          conditionalPanel("input.exoten_overview % 2 == 1",
+            wellPanel(
+              uiOutput("exoten_overviewText")
+            )
           )
         ),
         


### PR DESCRIPTION
This PR provides code to create a table overview button with the same functionality and look as the table legend button, under the taxa table of the tab "Checklist indicators".