### PR TITLE
Update trias to v3.1.0

### DIFF
--- a/alienSpecies/DESCRIPTION
+++ b/alienSpecies/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     terra,
 	  testthat (>= 3.0.0),
     tidyr,
-	  trias (>= 3.0.0),
+	  trias (>= 3.1.0),
 	  webshot2,
 	  xtable
 Suggests:
@@ -44,5 +44,5 @@ Suggests:
 RoxygenNote: 7.3.1
 Remotes: 
     inbo/INBOtheme@v0.5.9,
-    trias-project/trias@v3.0.0
+    trias-project/trias@v3.1.0
 Config/testthat/edition: 3

--- a/alienSpecies/inst/app/serverFiles/serverChecklist.R
+++ b/alienSpecies/inst/app/serverFiles/serverChecklist.R
@@ -558,6 +558,7 @@ observeEvent(input$exoten_tabs, {
       triasFunction = "indicator_native_range_year",
       triasArgs = reactive({
           list(
+            x_include_missing = TRUE,
             x_major_scale_stepsize = results$exoten_xMajor(),
             x_lab = translate(results$translations, "year")$title,
             y_lab = translate(results$translations, "number")$title


### PR DESCRIPTION
Use latest version of TrIAS (v3.1.0).

@SanderDevisscher @soriadelva Machteld had already made this change for the 1.3.0 milestone. In the same commit, she ensured that years with no data were also shown in the graph on the 'Checklist indicators - Origin' tab.
As I assume this is why you want to use the latest version of TrIAS in production, I have included this in the pull request. However, let me know if you don't want this to be added to the hotfix.