### PR TITLE
Add possibility to do workflow dispatch

### DIFF
--- a/.github/workflows/deployment_prod.yml
+++ b/.github/workflows/deployment_prod.yml
@@ -1,6 +1,7 @@
 on:
   release:
     types: [created, released]
+  workflow_dispatch:
 jobs:
   build:
     name: Build and upload Docker image


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by enabling manual triggering of the production deployment workflow. This allows users to start the deployment process using the "Run workflow" button in the GitHub Actions UI.

* Added `workflow_dispatch` to `.github/workflows/deployment_prod.yml` to allow manual workflow runs.