### PR TITLE
Pin GitHub Actions to full commit SHA for security hardening

### DIFF
--- a/.github/workflows/deployment_prod.yml
+++ b/.github/workflows/deployment_prod.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -20,7 +20,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
       - name: Build, tag, and push docker image to Amazon ECR
         env:

--- a/.github/workflows/deployment_uat.yml
+++ b/.github/workflows/deployment_uat.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -21,7 +21,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
 
       - name: Build, tag, and push docker image to Amazon ECR
         env:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files for both production and UAT deployments to use specific commit SHAs for GitHub Actions instead of version tags. This change improves security and reliability by ensuring that the workflows always use the exact same version of each action, preventing unexpected changes due to upstream updates.

**Workflow dependency pinning:**

* `.github/workflows/deployment_prod.yml` and `.github/workflows/deployment_uat.yml`: Updated `actions/checkout`, `aws-actions/configure-aws-credentials`, and `aws-actions/amazon-ecr-login` to use specific commit SHAs instead of version tags. [[1]](diffhunk://#diff-1c84ff745878694f6736ac5446c398985b5b852f955369b9db0fc4599d503a71L11-R14) [[2]](diffhunk://#diff-1c84ff745878694f6736ac5446c398985b5b852f955369b9db0fc4599d503a71L23-R23) [[3]](diffhunk://#diff-38f7457004916158f2df8ad682a1f937b5ef5d18540fbacafd6527673d2d9a97L12-R15) [[4]](diffhunk://#diff-38f7457004916158f2df8ad682a1f937b5ef5d18540fbacafd6527673d2d9a97L24-R24)